### PR TITLE
transform _id into id during returns

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -41,7 +41,7 @@ export class AuthService {
    * @param user - The user object to be cleaned.
    * @returns The cleaned user object without the password field.
    */
-  private cleanUser(user: User) {
+  cleanUser(user: User) {
     const { _id, password, token, ...cleanedUser } = user;
     return {
       ...cleanedUser,

--- a/src/auth/local.strategy.ts
+++ b/src/auth/local.strategy.ts
@@ -39,8 +39,17 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     //   ? this.authService.generateJwtToken(user)
     //   : Promise.reject(new UnauthorizedException());
 
+    /*
     return user
       ? { ...user, access_token: this.authService.generateJwtToken(user) }
+      : Promise.reject(new UnauthorizedException('Invalid email or password'));
+    */
+
+    return user
+      ? {
+          ...(await this.authService.cleanUser(user)),
+          access_token: this.authService.generateJwtToken(user),
+        }
       : Promise.reject(new UnauthorizedException('Invalid email or password'));
   }
 }

--- a/src/schema/job-post/provider.job-post.schema.ts
+++ b/src/schema/job-post/provider.job-post.schema.ts
@@ -9,6 +9,14 @@ export type JobPostDocument = HydratedDocument<JobPost>;
 @Schema({
   collection: 'job-post',
   timestamps: false,
+  toJSON: {
+    virtuals: true,
+    transform: function (doc, ret) {
+      ret.id = ret._id;
+      delete ret._id;
+      delete ret.__v;
+    },
+  },
 })
 export class JobPost extends Document {
   @Prop()

--- a/src/schema/users/user.schema.ts
+++ b/src/schema/users/user.schema.ts
@@ -5,7 +5,9 @@ import { USER_ROLE } from 'src/constants/role.user.enum';
 
 export type UserDocument = HydratedDocument<User>;
 
-@Schema({ collection: 'user' })
+@Schema({
+  collection: 'user',
+})
 export class User extends Document {
   @Prop()
   firstName: string;


### PR DESCRIPTION
# Description : 
1. Transform _id to id before returning documents
2. during login server responding with data which is also include password fix that

# Solution : 
1.  assigned the value of the '_id' field (default MongoDB identifier) to a new property called 'id'
2. during login sending only essential data avoiding sensitive field like password
